### PR TITLE
Adding Checksum Verifications so testing coverage is 100%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+#yarn lock file
+yarn.lock

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -22,7 +22,7 @@ module.exports = {
   mod7: (sequence, checkDigit) => {
     return sequence % 7 === Number.parseInt(checkDigit);
   },
-  s10: (sequence, checkDigit, extras = {}) => {
+  s10: (sequence, checkDigit) => {
     const total = sequence
       .split("")
       .map((c, i) => {

--- a/test.js
+++ b/test.js
@@ -169,6 +169,25 @@ test("S10: have valid decode", t => {
   });
 });
 
+// additional s10 checks for switch statement
+const extras = { name: 's10' };
+const validation = require("./src/utils/validation");
+
+const s10TrackingSequence1 = "29492510"; // From Tracking number "RB294925100GB"
+const checkDigit1 = 0;
+test("S10: checking for check = 0", t => {
+  const answer = validation.s10(s10TrackingSequence1, checkDigit1, extras);
+  t.truthy(answer)
+});
+
+
+const s10TrackingSequence0 = "89006891"; // From Tracking number "RB890068915GB"
+const checkDigit0 = 5;
+test("S10: checking for check = 5", t => {
+  const answer = validation.s10(s10TrackingSequence0, checkDigit0, extras);
+  t.truthy(answer)
+});
+
 // tracking number additional data for USPS 20
 const uspsTrackingNumber = "0307 1790 0005 2348 3741";
 

--- a/test.js
+++ b/test.js
@@ -394,26 +394,26 @@ test("S10: checksum 0", t => {
   const s10TrackingSequence = "29492510";
   const checkDigit = 0;
   const answer = validation.s10(s10TrackingSequence, checkDigit);
-  t.truthy(answer)
+  t.true(answer)
 });
 
 test("S10: fail checksum 0", t => {
   const s10TrackingSequence = "29492510";
   const checkDigit = 999;
   const answer = validation.s10(s10TrackingSequence, checkDigit);
-  t.falsy(answer)
+  t.false(answer)
 });
 
 test("S10: checksum 5", t => {
   const s10TrackingSequence = "89006891";
   const checkDigit = 5;
   const answer = validation.s10(s10TrackingSequence, checkDigit);
-  t.truthy(answer)
+  t.true(answer)
 });
 
 test("S10: fail checksum 5", t => {
   const s10TrackingSequence = "89006891";
   const checkDigit = 999;
   const answer = validation.s10(s10TrackingSequence, checkDigit);
-  t.falsy(answer)
+  t.false(answer)
 });

--- a/test.js
+++ b/test.js
@@ -240,74 +240,6 @@ test("USPS 20: have valid decode", t => {
   });
 });
 
-// tracking number fedex
-const fedexTrackingNumber = "000123450000000027";
-
-test("FedEx: report correct courier name", t => {
-  const { courierName } = new TrackingNumber(fedexTrackingNumber);
-  t.is(courierName, "FedEx");
-});
-
-test("FedEx: report correct courier code", t => {
-  const { courierCode } = new TrackingNumber(fedexTrackingNumber);
-  t.is(courierCode, "fedex");
-});
-
-test("FedEx: report correct service", t => {
-  const { serviceType } = new TrackingNumber(fedexTrackingNumber);
-  t.falsy(serviceType);
-});
-
-test("FedEx: report correct missing service description", t => {
-  const { serviceDescription } = new TrackingNumber(fedexTrackingNumber);
-  t.falsy(serviceDescription);
-});
-
-test("FedEx: report correct no shipperId", t => {
-  const { shipperId } = new TrackingNumber(fedexTrackingNumber);
-  t.falsy(shipperId);
-});
-
-test("FedEx: report correct no destination", t => {
-  const { destinationZip } = new TrackingNumber(fedexTrackingNumber);
-  t.falsy(destinationZip);
-});
-
-test("FedEx: report correct package type", t => {
-  const { packageType } = new TrackingNumber(fedexTrackingNumber);
-  t.is(packageType, "case/carton");
-});
-
-test("FedEx: have valid tracking url", t => {
-  const { trackingUrl, trackingNumber } = new TrackingNumber(
-    fedexTrackingNumber
-  );
-  t.truthy(trackingUrl);
-  t.true(trackingUrl.includes(trackingNumber));
-});
-
-test("FedEx: have valid info", t => {
-  const { info, trackingUrl } = new TrackingNumber(fedexTrackingNumber);
-  t.deepEqual(info, {
-    courier: { name: "FedEx", courierCode: "fedex" },
-    shipperId: undefined,
-    trackingUrl,
-    destinationZip: undefined,
-    packageType: "case/carton",
-    serviceDescription: undefined,
-    serviceType: undefined
-  });
-});
-
-test("FedEx: have valid decode", t => {
-  const { decode } = new TrackingNumber(fedexTrackingNumber);
-  t.deepEqual(decode, {
-    CheckDigit: "7",
-    SerialNumber: "012345000000002",
-    ShippingContainerType: "00"
-  });
-});
-
 // tracking number additional data for USPS 34v2
 const usps34v2TrackingNumber = "4201002334249200190132607600833457";
 
@@ -386,6 +318,74 @@ test("USPS 34v2: have valid decode", t => {
     RoutingNumber: "3424",
     SerialNumber: "920019013260760083345",
     ShipperId: "00190132"
+  });
+});
+
+// tracking number fedex
+const fedexTrackingNumber = "000123450000000027";
+
+test("FedEx: report correct courier name", t => {
+  const { courierName } = new TrackingNumber(fedexTrackingNumber);
+  t.is(courierName, "FedEx");
+});
+
+test("FedEx: report correct courier code", t => {
+  const { courierCode } = new TrackingNumber(fedexTrackingNumber);
+  t.is(courierCode, "fedex");
+});
+
+test("FedEx: report correct service", t => {
+  const { serviceType } = new TrackingNumber(fedexTrackingNumber);
+  t.falsy(serviceType);
+});
+
+test("FedEx: report correct missing service description", t => {
+  const { serviceDescription } = new TrackingNumber(fedexTrackingNumber);
+  t.falsy(serviceDescription);
+});
+
+test("FedEx: report correct no shipperId", t => {
+  const { shipperId } = new TrackingNumber(fedexTrackingNumber);
+  t.falsy(shipperId);
+});
+
+test("FedEx: report correct no destination", t => {
+  const { destinationZip } = new TrackingNumber(fedexTrackingNumber);
+  t.falsy(destinationZip);
+});
+
+test("FedEx: report correct package type", t => {
+  const { packageType } = new TrackingNumber(fedexTrackingNumber);
+  t.is(packageType, "case/carton");
+});
+
+test("FedEx: have valid tracking url", t => {
+  const { trackingUrl, trackingNumber } = new TrackingNumber(
+    fedexTrackingNumber
+  );
+  t.truthy(trackingUrl);
+  t.true(trackingUrl.includes(trackingNumber));
+});
+
+test("FedEx: have valid info", t => {
+  const { info, trackingUrl } = new TrackingNumber(fedexTrackingNumber);
+  t.deepEqual(info, {
+    courier: { name: "FedEx", courierCode: "fedex" },
+    shipperId: undefined,
+    trackingUrl,
+    destinationZip: undefined,
+    packageType: "case/carton",
+    serviceDescription: undefined,
+    serviceType: undefined
+  });
+});
+
+test("FedEx: have valid decode", t => {
+  const { decode } = new TrackingNumber(fedexTrackingNumber);
+  t.deepEqual(decode, {
+    CheckDigit: "7",
+    SerialNumber: "012345000000002",
+    ShippingContainerType: "00"
   });
 });
 

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 import test from "ava";
 import TrackingNumber from "./src";
+const validation = require("./src/utils/validation");
 
 // a tracking number
 test("throws error when no provided tracking number", t => {
@@ -167,25 +168,6 @@ test("S10: have valid decode", t => {
     SerialNumber: "12345678",
     ServiceType: "RB"
   });
-});
-
-// additional s10 checks for switch statement
-const extras = { name: 's10' };
-const validation = require("./src/utils/validation");
-
-const s10TrackingSequence1 = "29492510"; // From Tracking number "RB294925100GB"
-const checkDigit1 = 0;
-test("S10: checking for check = 0", t => {
-  const answer = validation.s10(s10TrackingSequence1, checkDigit1, extras);
-  t.truthy(answer)
-});
-
-
-const s10TrackingSequence0 = "89006891"; // From Tracking number "RB890068915GB"
-const checkDigit0 = 5;
-test("S10: checking for check = 5", t => {
-  const answer = validation.s10(s10TrackingSequence0, checkDigit0, extras);
-  t.truthy(answer)
 });
 
 // tracking number additional data for USPS 20
@@ -405,4 +387,33 @@ test("USPS 34v2: have valid decode", t => {
     SerialNumber: "920019013260760083345",
     ShipperId: "00190132"
   });
+});
+
+// checksum tests
+test("S10: checksum 0", t => {
+  const s10TrackingSequence = "29492510";
+  const checkDigit = 0;
+  const answer = validation.s10(s10TrackingSequence, checkDigit);
+  t.truthy(answer)
+});
+
+test("S10: fail checksum 0", t => {
+  const s10TrackingSequence = "29492510";
+  const checkDigit = 999;
+  const answer = validation.s10(s10TrackingSequence, checkDigit);
+  t.falsy(answer)
+});
+
+test("S10: checksum 5", t => {
+  const s10TrackingSequence = "89006891";
+  const checkDigit = 5;
+  const answer = validation.s10(s10TrackingSequence, checkDigit);
+  t.truthy(answer)
+});
+
+test("S10: fail checksum 5", t => {
+  const s10TrackingSequence = "89006891";
+  const checkDigit = 999;
+  const answer = validation.s10(s10TrackingSequence, checkDigit);
+  t.falsy(answer)
 });


### PR DESCRIPTION
- Moved Fedex tests out from the middle of USPS and into their own block
- Added checksum tests at the end to test other paths of switch statement
- Added falsy tests for checksum to make sure a back checksum returns false